### PR TITLE
Feature/banner shows typed suggestion

### DIFF
--- a/Keyboard/BannerView.swift
+++ b/Keyboard/BannerView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct BannerItem {
     public let title: String
-    public let value: Any?
+    public let value: String
 }
 
 public protocol BannerViewDelegate {

--- a/Keyboard/DivvunSpellBannerPlugin.swift
+++ b/Keyboard/DivvunSpellBannerPlugin.swift
@@ -20,15 +20,17 @@ class SuggestionOp: Operation {
         guard let speller = plugin.speller else { return }
 
         
+        let currentWord = BannerItem(title: "\"\(word)\"", value: "currentWord")
+        
         let suggestions = (try? speller
             .suggest(word: word)//, count: 3, maxWeight: 4999.99)
-            .prefix(3)
+            .prefix(2)
             .map { BannerItem(title: $0, value: "suggestion") }) ?? []
 
         if !isCancelled {
             DispatchQueue.main.async {
                 plugin.banner.isHidden = false
-                plugin.banner.items = suggestions
+                plugin.banner.items = [currentWord] + suggestions
             }
         }
     }

--- a/Keyboard/DivvunSpellBannerPlugin.swift
+++ b/Keyboard/DivvunSpellBannerPlugin.swift
@@ -20,12 +20,12 @@ class SuggestionOp: Operation {
         guard let speller = plugin.speller else { return }
 
         
-        let currentWord = BannerItem(title: "\"\(word)\"", value: "currentWord")
+        let currentWord = BannerItem(title: "\"\(word)\"", value: word)
         
         let suggestions = (try? speller
             .suggest(word: word)//, count: 3, maxWeight: 4999.99)
             .prefix(2)
-            .map { BannerItem(title: $0, value: "suggestion") }) ?? []
+            .map { BannerItem(title: $0, value: $0) }) ?? []
 
         if !isCancelled {
             DispatchQueue.main.async {
@@ -54,7 +54,7 @@ extension DivvunSpellBannerPlugin: BannerViewDelegate {
             return
         }
 
-        keyboard.replaceSelected(with: item.title)
+        keyboard.replaceSelected(with: item.value)
         // TODO: Sami languages want to autosuggest compounds, so let's not add spaces without configuration
 //        keyboard.insertText(" ")
         opQueue.cancelAllOperations()

--- a/Keyboard/DivvunSpellBannerPlugin.swift
+++ b/Keyboard/DivvunSpellBannerPlugin.swift
@@ -48,12 +48,6 @@ extension DivvunSpellBannerPlugin: BannerViewDelegate {
     }
 
     public func didSelectBannerItem(_ banner: BannerView, item: BannerItem) {
-        if let value = item.value as? String, value == "error" {
-            banner.items = []
-            banner.isHidden = true
-            return
-        }
-
         keyboard.replaceSelected(with: item.value)
         // TODO: Sami languages want to autosuggest compounds, so let's not add spaces without configuration
 //        keyboard.insertText(" ")


### PR DESCRIPTION
Fixes #34, fixes #41

Shows user's current input in quotes as the first suggestion in the banner.