### PR TITLE
Feature/popover background color

### DIFF
--- a/Keyboard/Theme.swift
+++ b/Keyboard/Theme.swift
@@ -49,7 +49,6 @@ protocol ThemeType {
     var specialKeyColor: UIColor { get }
     var popupColor: UIColor { get }
     var backgroundColor: UIColor { get }
-    var underColor: UIColor { get }
     var textColor: UIColor { get }
     var inactiveTextColor: UIColor { get }
     var borderColor: UIColor { get }
@@ -102,7 +101,6 @@ class LightThemeImpl: ThemeType {
     var specialKeyColor = UIColor(r: 162, g: 167, b: 177)
     var popupColor = UIColor.white
     var backgroundColor = UIColor(r: 208, g: 210, b: 216)
-    var underColor = UIColor(hue: 0.611, saturation: 0.04, brightness: 0.56, alpha: 1)
     var textColor = UIColor.black
     var inactiveTextColor: UIColor = UIColor(white: 0.0, alpha: 0.3)
     var borderColor = UIColor.clear
@@ -161,7 +159,6 @@ class DarkThemeImpl: ThemeType {
     var regularKeyColor = UIColor.lightGray.withAlphaComponent(CGFloat(0.4))
     var specialKeyColor = UIColor.gray.withAlphaComponent(CGFloat(0.3))
     var popupColor = UIColor(r: 111, g: 103, b: 111, a: 1.0)
-    var underColor = UIColor(r: 39, g: 18, b: 39, a: 0.4)
     var textColor = UIColor.white
     var inactiveTextColor: UIColor = UIColor.lightGray
     var borderColor = UIColor.clear

--- a/Keyboard/Theme.swift
+++ b/Keyboard/Theme.swift
@@ -158,7 +158,12 @@ class DarkThemeImpl: ThemeType {
     var keyShadowColor: UIColor = UIColor(r: 103, g: 106, b: 110, a: 0.5)
     var regularKeyColor = UIColor.lightGray.withAlphaComponent(CGFloat(0.4))
     var specialKeyColor = UIColor.gray.withAlphaComponent(CGFloat(0.3))
-    var popupColor = UIColor(r: 111, g: 103, b: 111, a: 1.0)
+    
+    // Native iOS uses a transparent view for the popup (probably UIVisualEffectsView), so this should technically be dynamic depending on what color view
+    // lies beneath the keyboard (eg. If white, keys are lighter. If black, keys are darker).
+    // For now, use a color that's halfway between both to minimize contrast (against white background, keys are 124, against black, keys are 94)
+    var popupColor = UIColor(r: 109, g: 109, b: 109)
+    
     var textColor = UIColor.white
     var inactiveTextColor: UIColor = UIColor.lightGray
     var borderColor = UIColor.clear

--- a/Keyboard/Theme.swift
+++ b/Keyboard/Theme.swift
@@ -59,7 +59,6 @@ protocol ThemeType {
     var shiftTintColor: UIColor { get }
     var solidRegularKeyColor: UIColor { get }
     var solidSpecialKeyColor: UIColor { get }
-    var solidPopupColor: UIColor { get }
     var popupBorderColor: UIColor { get }
     var activeColor: UIColor { get }
     var activeTextColor: UIColor { get }
@@ -114,7 +113,6 @@ class LightThemeImpl: ThemeType {
     var shiftTintColor: UIColor = UIColor.black
     var solidRegularKeyColor: UIColor { return regularKeyColor }
     var solidSpecialKeyColor = UIColor(r: 183, g: 191, b: 202)
-    var solidPopupColor: UIColor { return popupColor }
     var activeColor: UIColor = UIColor(r: 31, g: 126, b: 249)
     var activeTextColor: UIColor = UIColor.white
     lazy var altKeyTextColor: UIColor = { screenInches >= 11
@@ -173,7 +171,6 @@ class DarkThemeImpl: ThemeType {
     var shiftTintColor: UIColor = UIColor.black
     var solidRegularKeyColor = UIColor(r: 83, g: 83, b: 83)
     var solidSpecialKeyColor = UIColor(r: 45, g: 45, b: 45)
-    var solidPopupColor: UIColor { return solidRegularKeyColor }
     var activeColor: UIColor = UIColor(r: 31, g: 126, b: 249)
     var activeTextColor: UIColor = UIColor.white
     var altKeyFont: UIFont { return IPadThemeBase.altKeyFont }


### PR DESCRIPTION
Fixes #53 

This was a bit more involved than expected. The native keyboard, when in dark mode, uses blurred transparent views. This means that when a white background is behind the keyboard, the keys are slightly brighter than when a black background is beneath the keyboard. We're currently doing this for keys, but it's more work to get our popover doing the same.

Since this seemed like more work than it was worth, I've instead found a solid color for the popover that is between the key's brightest possible color (when on white background) and they darkest color (when on black), to minimize contrast between other keys.

Old:
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-07 at 12 51 59](https://user-images.githubusercontent.com/431529/71901284-ef05a480-315f-11ea-8d48-1ac830aa5b87.png)

New:
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-07 at 15 12 23](https://user-images.githubusercontent.com/431529/71901395-2a07d800-3160-11ea-859e-da5e663e7511.png)

Notice that in the above screenshot the popover is slightly lighter than the other keys (because we're against a black background), but it's much more similar than before.
