### PR TITLE
fix redraw on old ios

### DIFF
--- a/Keyboard/Controllers/EntryPoint.swift
+++ b/Keyboard/Controllers/EntryPoint.swift
@@ -4,6 +4,7 @@ class EntryKeyboard: KeyboardViewController {
     private var bannerPlugin: DivvunSpellBannerPlugin?
     private var showsBanner = true
 
+    /*
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(withBanner: showsBanner)
         if showsBanner {
@@ -14,8 +15,12 @@ class EntryKeyboard: KeyboardViewController {
     required init?(coder: NSCoder) {
         fatalError()
     }
+    */
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        if showsBanner {
+            bannerPlugin = DivvunSpellBannerPlugin(keyboard: self)
+        }
     }
 }

--- a/Keyboard/Controllers/EntryPoint.swift
+++ b/Keyboard/Controllers/EntryPoint.swift
@@ -4,18 +4,13 @@ class EntryKeyboard: KeyboardViewController {
     private var bannerPlugin: DivvunSpellBannerPlugin?
     private var showsBanner = true
 
-    /*
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(withBanner: showsBanner)
-        if showsBanner {
-            bannerPlugin = DivvunSpellBannerPlugin(keyboard: self)
-        }
     }
 
     required init?(coder: NSCoder) {
-        fatalError()
+        fatalError("init(coder:) has not been implemented")
     }
-    */
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -242,6 +242,12 @@ open class KeyboardViewController: UIInputViewController {
         }
     }
 
+    private func updateHeightConstraint() {
+        DispatchQueue.main.async {
+            self.heightConstraint?.constant = self.preferredHeight
+        }
+    }
+
     open override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -375,12 +381,6 @@ open class KeyboardViewController: UIInputViewController {
         bannerView.topAnchor.constraint(equalTo: keyboardContainer.topAnchor).isActive = true
 
         bannerView.isHidden = false
-    }
-
-    private func updateHeightConstraint() {
-        DispatchQueue.main.async {
-            self.heightConstraint?.constant = self.preferredHeight
-        }
     }
 
     private var isFirstRun = true

--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -245,7 +245,7 @@ open class KeyboardViewController: UIInputViewController {
     private func initHeightConstraint() {
         // If this is removed, iPhone 5s glitches before finding the correct height.
         DispatchQueue.main.async {
-            self.heightConstraint = self.view.heightAnchor
+            self.heightConstraint = self.keyboardContainer.heightAnchor
                 .constraint(equalToConstant: self.preferredHeight)
                 .enable(priority: UILayoutPriority(999))
         }
@@ -277,7 +277,11 @@ open class KeyboardViewController: UIInputViewController {
         keyboardContainer = UIView()
         keyboardContainer.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(keyboardContainer)
-        keyboardContainer.fill(superview: view)
+        keyboardContainer.topAnchor.constraint(equalTo: view.topAnchor).enable(priority: .defaultHigh)
+        keyboardContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor).enable(priority: .required)
+        keyboardContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor).enable(priority: .required)
+        keyboardContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor).enable(priority: .required)
+
         keyboardContainer.backgroundColor = UIColor.green.withAlphaComponent(0.3)
     }
 
@@ -386,8 +390,7 @@ open class KeyboardViewController: UIInputViewController {
 
     private func updateHeightConstraint() {
         DispatchQueue.main.async {
-            guard let heightConstraint = self.heightConstraint else { return }
-            heightConstraint.constant = self.preferredHeight
+            self.heightConstraint?.constant = self.preferredHeight
         }
     }
 

--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -71,23 +71,14 @@ open class KeyboardViewController: UIInputViewController {
     public init(withBanner: Bool) {
         showsBanner = withBanner
         super.init(nibName: nil, bundle: nil)
-        commonInit(withBanner: withBanner)
     }
 
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        commonInit()
     }
 
     public required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        commonInit()
-    }
-
-    private func commonInit(withBanner: Bool = false) {
-//        view.translatesAutoresizingMaskIntoConstraints = false
-//        inputView?.allowsSelfSizing = true
-//        setupKeyboardView(withBanner: withBanner)
+        fatalError("init(coder:) has not been implemented")
     }
 
     private(set) lazy var definitions: [KeyboardDefinition] = {

--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -538,6 +538,7 @@ open class KeyboardViewController: UIInputViewController {
 
     open override func willTransition(to newCollection: UITraitCollection,
                                       with coordinator: UIViewControllerTransitionCoordinator) {
+        super.willTransition(to: newCollection, with: coordinator)
         coordinator.animate(alongsideTransition: { _ in
             self.checkDarkMode()
         }, completion: nil)

--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -281,8 +281,6 @@ open class KeyboardViewController: UIInputViewController {
         keyboardContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor).enable(priority: .required)
         keyboardContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor).enable(priority: .required)
         keyboardContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor).enable(priority: .required)
-
-        keyboardContainer.backgroundColor = UIColor.green.withAlphaComponent(0.3)
     }
 
     private func setupKeyboardView(withBanner: Bool) {

--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -66,7 +66,10 @@ open class KeyboardViewController: UIInputViewController {
     public private(set) var keyboardDefinition: KeyboardDefinition!
     private var keyboardMode: KeyboardMode = .normal
 
+    private var showsBanner = true
+
     public init(withBanner: Bool) {
+        showsBanner = withBanner
         super.init(nibName: nil, bundle: nil)
         commonInit(withBanner: withBanner)
     }
@@ -82,9 +85,9 @@ open class KeyboardViewController: UIInputViewController {
     }
 
     private func commonInit(withBanner: Bool = false) {
-        view.translatesAutoresizingMaskIntoConstraints = false
-        inputView?.allowsSelfSizing = true
-        setupKeyboardView(withBanner: withBanner)
+//        view.translatesAutoresizingMaskIntoConstraints = false
+//        inputView?.allowsSelfSizing = true
+//        setupKeyboardView(withBanner: withBanner)
     }
 
     private(set) lazy var definitions: [KeyboardDefinition] = {
@@ -257,6 +260,8 @@ open class KeyboardViewController: UIInputViewController {
 
         keyboardDefinition = definitions[kbdIndex]
         deadKeyHandler = DeadKeyHandler(keyboard: keyboardDefinition)
+
+        setupKeyboardView(withBanner: showsBanner)
 
         isSoundEnabled = KeyboardSettings.isKeySoundEnabled
 

--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -57,6 +57,7 @@ extension UIScreen {
 
 open class KeyboardViewController: UIInputViewController {
     @IBOutlet var nextKeyboardButton: UIButton!
+    private var keyboardContainer: UIView!
     private var keyboardView: KeyboardViewProvider!
     private var heightConstraint: NSLayoutConstraint!
     private var extraSpacingView: UIView!
@@ -262,11 +263,26 @@ open class KeyboardViewController: UIInputViewController {
         print("\(definitions.map { $0.locale })")
     }
 
+    private func setupKeyboardContainer() {
+        if keyboardContainer != nil {
+            keyboardContainer.removeFromSuperview()
+            keyboardContainer = nil
+        }
+
+        keyboardContainer = UIView()
+        keyboardContainer.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(keyboardContainer)
+        keyboardContainer.fill(superview: view)
+        keyboardContainer.backgroundColor = UIColor.green.withAlphaComponent(0.3)
+    }
+
     private func setupKeyboardView(withBanner: Bool) {
         if keyboardView != nil {
             keyboardView.remove()
             keyboardView = nil
         }
+
+        setupKeyboardContainer()
 
         switch keyboardMode {
         case .split:
@@ -280,23 +296,23 @@ open class KeyboardViewController: UIInputViewController {
         if withBanner {
             setupBannerView()
         } else {
-            self.keyboardView.topAnchor.constraint(equalTo: view.topAnchor).enable()
+            self.keyboardView.topAnchor.constraint(equalTo: keyboardContainer.topAnchor).enable()
         }
     }
 
     private func setupSplitKeyboard() {
         let splitKeyboard = SplitKeyboardView(definition: keyboardDefinition, theme: theme)
 
-        view.addSubview(splitKeyboard.leftKeyboardView)
-        view.addSubview(splitKeyboard.rightKeyboardView)
+        keyboardContainer.addSubview(splitKeyboard.leftKeyboardView)
+        keyboardContainer.addSubview(splitKeyboard.rightKeyboardView)
 
-        splitKeyboard.leftKeyboardView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-        splitKeyboard.leftKeyboardView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-        splitKeyboard.leftKeyboardView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.25).isActive = true
+        splitKeyboard.leftKeyboardView.bottomAnchor.constraint(equalTo: keyboardContainer.bottomAnchor).isActive = true
+        splitKeyboard.leftKeyboardView.leftAnchor.constraint(equalTo: keyboardContainer.leftAnchor).isActive = true
+        splitKeyboard.leftKeyboardView.widthAnchor.constraint(equalTo: keyboardContainer.widthAnchor, multiplier: 0.25).isActive = true
 
-        splitKeyboard.rightKeyboardView.bottomAnchor.constraint(equalTo: view.bottomAnchor).enable()
-        splitKeyboard.rightKeyboardView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.25).enable()
-        splitKeyboard.rightKeyboardView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        splitKeyboard.rightKeyboardView.bottomAnchor.constraint(equalTo: keyboardContainer.bottomAnchor).enable()
+        splitKeyboard.rightKeyboardView.widthAnchor.constraint(equalTo: keyboardContainer.widthAnchor, multiplier: 0.25).enable()
+        splitKeyboard.rightKeyboardView.rightAnchor.constraint(equalTo: keyboardContainer.rightAnchor).isActive = true
 
         splitKeyboard.rightKeyboardView.topAnchor.constraint(equalTo: splitKeyboard.leftKeyboardView.topAnchor).enable()
         splitKeyboard.rightKeyboardView.heightAnchor.constraint(equalTo: splitKeyboard.leftKeyboardView.heightAnchor).enable()
@@ -314,15 +330,15 @@ open class KeyboardViewController: UIInputViewController {
         let keyboardView = KeyboardView(definition: keyboardDefinition, theme: theme)
         keyboardView.translatesAutoresizingMaskIntoConstraints = false
 
-        view.addSubview(keyboardView)
+        keyboardContainer.addSubview(keyboardView)
 
-        keyboardView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-        keyboardView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8).isActive = true
+        keyboardView.bottomAnchor.constraint(equalTo: keyboardContainer.bottomAnchor).isActive = true
+        keyboardView.widthAnchor.constraint(equalTo: keyboardContainer.widthAnchor, multiplier: 0.8).isActive = true
 
         if mode == .left {
-            keyboardView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+            keyboardView.leftAnchor.constraint(equalTo: keyboardContainer.leftAnchor).isActive = true
         } else if mode == .right {
-            keyboardView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+            keyboardView.rightAnchor.constraint(equalTo: keyboardContainer.rightAnchor).isActive = true
         }
 
         keyboardView.delegate = self
@@ -334,11 +350,11 @@ open class KeyboardViewController: UIInputViewController {
         let keyboardView = KeyboardView(definition: keyboardDefinition, theme: theme)
         keyboardView.translatesAutoresizingMaskIntoConstraints = false
 
-        view.addSubview(keyboardView)
+        keyboardContainer.addSubview(keyboardView)
 
-        keyboardView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-        keyboardView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-        keyboardView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        keyboardView.bottomAnchor.constraint(equalTo: keyboardContainer.bottomAnchor).isActive = true
+        keyboardView.leftAnchor.constraint(equalTo: keyboardContainer.leftAnchor).isActive = true
+        keyboardView.rightAnchor.constraint(equalTo: keyboardContainer.rightAnchor).isActive = true
 
         keyboardView.delegate = self
 
@@ -351,14 +367,14 @@ open class KeyboardViewController: UIInputViewController {
 
         bannerView.translatesAutoresizingMaskIntoConstraints = false
 
-        view.insertSubview(bannerView, at: 0)
+        keyboardContainer.insertSubview(bannerView, at: 0)
 
         bannerView.heightAnchor.constraint(equalToConstant: theme.bannerHeight).isActive = true
-        bannerView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-        bannerView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        bannerView.leftAnchor.constraint(equalTo: keyboardContainer.leftAnchor).isActive = true
+        bannerView.rightAnchor.constraint(equalTo: keyboardContainer.rightAnchor).isActive = true
 
         bannerView.bottomAnchor.constraint(equalTo: keyboardView.topAnchor).isActive = true
-        bannerView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        bannerView.topAnchor.constraint(equalTo: keyboardContainer.topAnchor).isActive = true
 
         bannerView.isHidden = false
     }

--- a/Keyboard/Utility/ViewDebugger.swift
+++ b/Keyboard/Utility/ViewDebugger.swift
@@ -1,7 +1,11 @@
 import UIKit
 
 class ViewDebugger {
-    public static func printViewHierarchy(view: UIView, indentLevel: Int = 0) {
+    public static func printViewHierarchy(view: UIView, indentLevel: Int = 0, depth: Int) {
+        guard depth > 0 else {
+            return
+        }
+
         let indent = String(repeating: "    ", count: indentLevel)
 
         let viewDescription = String(describing: view.self)
@@ -14,7 +18,7 @@ class ViewDebugger {
         }
 
         for subview in view.subviews {
-            printViewHierarchy(view: subview, indentLevel: indentLevel + 1)
+            printViewHierarchy(view: subview, indentLevel: indentLevel + 1, depth: depth - 1)
         }
     }
 }

--- a/Keyboard/Views/KeyboardView.swift
+++ b/Keyboard/Views/KeyboardView.swift
@@ -54,12 +54,6 @@ internal class KeyboardView: UIView,
         }
     }
 
-    override var intrinsicContentSize: CGSize {
-        // This must be implemented, otherwise the keyboard is too small.
-        // It doesn't matter that what's returned is bigger than the keyboard should actually be.
-        return CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
-    }
-
     private let reuseIdentifier = "cell"
     private let collectionView: UICollectionView
     private let layout = UICollectionViewFlowLayout()


### PR DESCRIPTION
Fixes #99 

For documentation's sake, here's how this fix works:
- It reverts the change that "fixed" the initial drawing of the keyboard, but broke the keyboard when rotating and on all versions of iOS below 13.
- It wraps the keyboard and banner in a container view so its height can be better controlled
- It allows breaking the constraint between the new container view and the containing `inputView`. This effectively means that the keyboard appears at a fixed height when loading, so the system-provided glitch doesn't squish the keyboard momentarily. The side effect is that redrawing the keyboard on rotation is slightly more shaky. This will be addressed in a separate PR.