### PR TITLE
Add Sentry to KeyboardViewController

### DIFF
--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -244,6 +244,16 @@ open class KeyboardViewController: UIInputViewController {
     open override func viewDidLoad() {
         super.viewDidLoad()
 
+        if let sentryDSN = Bundle.main.infoDictionary?["SentryDSN"] as? String {
+            do {
+                Client.shared = try Client(dsn: sentryDSN)
+                try Client.shared?.startCrashHandler()
+            } catch {
+                print("\(error)")
+                // Wrong DSN or KSCrash not installed
+            }
+        }
+
         guard let kbdIndex = Bundle.main.infoDictionary?["DivvunKeyboardIndex"] as? Int else {
             fatalError("There was no DivvunKeyboardIndex")
         }


### PR DESCRIPTION
This should be refactored out into a CrashReporter class to avoid code duplication. Doing this way for now as it's least prone to error.