### PR TITLE
Refactor KeyboardDefinition to use optional `currentDeviceLayout` property

### DIFF
--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -189,7 +189,7 @@ open class KeyboardViewController: UIInputViewController {
             preferredHeight = portraitHeight
         }
 
-        guard let layout = keyboardDefinition.layout else {
+        guard let layout = keyboardDefinition.currentDeviceLayout else {
             // this can happen if for instance we're on iPad and there's no iPad layout for this particular keyboard
             return preferredHeight
         }

--- a/Keyboard/Controllers/KeyboardViewController.swift
+++ b/Keyboard/Controllers/KeyboardViewController.swift
@@ -43,10 +43,8 @@ open class KeyboardViewController: UIInputViewController {
     private var heightConstraint: NSLayoutConstraint!
     private var extraSpacingView: UIView!
     private var deadKeyHandler: DeadKeyHandler!
-    public private(set) var keyboardDefinition: KeyboardDefinition?
+    public private(set) var keyboardDefinition: KeyboardDefinition!
     private var keyboardMode: KeyboardMode = .normal
-    private var keyboardName: String!
-    private var keyboardLocale: String!
 
     private var bannerManager: BannerManager?
 
@@ -54,10 +52,6 @@ open class KeyboardViewController: UIInputViewController {
 
     public var page: BaseKeyboard.KeyboardPage {
         keyboardView.page
-    }
-
-    private var keyboardNotSupportedOnThisDevice: Bool {
-        return keyboardView == nil
     }
 
     public init(withBanner: Bool) {
@@ -195,13 +189,13 @@ open class KeyboardViewController: UIInputViewController {
             preferredHeight = portraitHeight
         }
 
-        guard let keyboardDefinitionNormal = keyboardDefinition?.normal else {
+        guard let layout = keyboardDefinition.layout else {
             // this can happen if for instance we're on iPad and there's no iPad layout for this particular keyboard
             return preferredHeight
         }
 
         // Ordinarily a keyboard has 4 rows, iPad 12 inch+ has 5. Some have more. We calculate for that.
-        let rowCount = CGFloat(keyboardDefinitionNormal.count)
+        let rowCount = CGFloat(layout.normal.count)
         let normalRowCount: CGFloat = (UIDevice.current.dc.screenSize.sizeInches ?? 0.0) >= 12.0
             ? 5.0
             : 4.0
@@ -244,17 +238,18 @@ open class KeyboardViewController: UIInputViewController {
     }
 
     private func setupKeyboard() {
-        guard let keyboardDefinition = loadKeyboardDefinition() else {
+        self.keyboardDefinition = loadKeyboardDefinition()
+
+        guard keyboardDefinition.supportsCurrentDevice else {
             setupKeyboardNotSupportedOnThisDeviceView()
             return
         }
 
-        self.keyboardDefinition = keyboardDefinition
         deadKeyHandler = DeadKeyHandler(keyboard: keyboardDefinition)
         setupKeyboardView(keyboardDefinition, withBanner: showsBanner)
     }
 
-    private func loadKeyboardDefinition() -> KeyboardDefinition? {
+    private func loadKeyboardDefinition() -> KeyboardDefinition {
         let keyboardDefinitions: [KeyboardDefinition]
         let path = Bundle.top.url(forResource: "KeyboardDefinitions", withExtension: "json")!
         do {
@@ -281,22 +276,14 @@ open class KeyboardViewController: UIInputViewController {
             kbdIndex = index
         }
 
-        let keyboardDefinition = keyboardDefinitions[kbdIndex]
-        keyboardName = keyboardDefinition.name
-        keyboardLocale = keyboardDefinition.locale
-
-        guard keyboardDefinition.supportsCurrentDevice else {
-            return nil
-        }
-
-        return keyboardDefinition
+        return keyboardDefinitions[kbdIndex]
     }
 
     private func setupKeyboardNotSupportedOnThisDeviceView() {
         setupKeyboardContainer()
 
         let notSupportedLabel = UILabel()
-        notSupportedLabel.text = String(format: NSLocalizedString("keyboardNotSupported", comment: ""), keyboardName)
+        notSupportedLabel.text = String(format: NSLocalizedString("keyboardNotSupported", comment: ""), keyboardDefinition.name)
         notSupportedLabel.textAlignment = .center
         notSupportedLabel.lineBreakMode = .byWordWrapping
         notSupportedLabel.numberOfLines = 0
@@ -660,7 +647,7 @@ open class KeyboardViewController: UIInputViewController {
             if keyboardView != nil {
                 keyboardView.updateTheme(theme: theme)
             }
-            if keyboardNotSupportedOnThisDevice {
+            if keyboardDefinition.supportsCurrentDevice == false {
                 // resetup the keyboard not supported view to update its theme
                 setupKeyboardNotSupportedOnThisDeviceView()
             }
@@ -712,8 +699,8 @@ open class KeyboardViewController: UIInputViewController {
     // MARK: Actions
 
     @objc private func emailButtonTapped() {
-        let keyboardName = keyboardName!
-        let keyboardLocale = keyboardLocale!
+        let keyboardName = keyboardDefinition.name
+        let keyboardLocale = keyboardDefinition.locale
         let deviceName = DeviceVariant.from(traits: self.traitCollection).displayName()
 
         // TODO: get email dynamically from kbdgen bundle
@@ -740,9 +727,8 @@ open class KeyboardViewController: UIInputViewController {
     }
 
     @objc private func githubIssueButtonTapped() {
-        let keyboardLocale = keyboardLocale!
         let deviceName = DeviceVariant.from(traits: self.traitCollection).displayName()
-        let repo = "keyboard-\(keyboardLocale)"
+        let repo = "keyboard-\(keyboardDefinition.locale)"
         let coded = "https://github.com/giellalt/\(repo)/issues/new?labels=enhancement&title=Add+Support+for+\(deviceName)&body=Additional+notes+(optional):\n\n"
 
         guard let escaped = coded.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
@@ -868,9 +854,6 @@ extension KeyboardViewController: KeyboardViewDelegate {
     }
 
     private func updateKeyboardMode(_ keyboardMode: KeyboardMode) {
-        guard let keyboardDefinition = self.keyboardDefinition else {
-            return
-        }
         self.keyboardMode = keyboardMode
         setupKeyboardView(keyboardDefinition, withBanner: showsBanner)
     }
@@ -918,7 +901,7 @@ extension KeyboardViewController: BannerManagerDelegate {
             replaceSelected(with: inputText)
 
             // If the keyboard is not compounding, we add a space
-            if !self.keyboardDefinition!.features.contains(.compounding) {
+            if !self.keyboardDefinition.features.contains(.compounding) {
                 insertText(" ")
             }
         }

--- a/Keyboard/Controllers/SplitKeyboard.swift
+++ b/Keyboard/Controllers/SplitKeyboard.swift
@@ -60,7 +60,7 @@ final class SplitKeyboardView: KeyboardViewProvider {
     var rightKeyboardView: KeyboardView
 
     required init(definition: KeyboardDefinition, theme: ThemeType) {
-        guard let layout = definition.layout else {
+        guard let layout = definition.currentDeviceLayout else {
             fatalError("Keyboard definition must have a layout.")
         }
         let leftDefinition = definition.copy(

--- a/Keyboard/Controllers/SplitKeyboard.swift
+++ b/Keyboard/Controllers/SplitKeyboard.swift
@@ -60,18 +60,21 @@ final class SplitKeyboardView: KeyboardViewProvider {
     var rightKeyboardView: KeyboardView
 
     required init(definition: KeyboardDefinition, theme: ThemeType) {
+        guard let layout = definition.layout else {
+            fatalError("Keyboard definition must have a layout.")
+        }
         let leftDefinition = definition.copy(
-            normal: leftHalf(definition.normal.splitAndBalanceSpacebar()),
-            shifted: leftHalf(definition.shifted.splitAndBalanceSpacebar()),
-            symbols1: leftHalf(definition.symbols1.splitAndBalanceSpacebar()),
-            symbols2: leftHalf(definition.symbols2.splitAndBalanceSpacebar())
+            normal: leftHalf(layout.normal.splitAndBalanceSpacebar()),
+            shifted: leftHalf(layout.shifted.splitAndBalanceSpacebar()),
+            symbols1: leftHalf(layout.symbols1.splitAndBalanceSpacebar()),
+            symbols2: leftHalf(layout.symbols2.splitAndBalanceSpacebar())
         )
 
         let rightDefinition = definition.copy(
-            normal: rightHalf(definition.normal.splitAndBalanceSpacebar()),
-            shifted: rightHalf(definition.shifted.splitAndBalanceSpacebar()),
-            symbols1: rightHalf(definition.symbols1.splitAndBalanceSpacebar()),
-            symbols2: rightHalf(definition.symbols2.splitAndBalanceSpacebar())
+            normal: rightHalf(layout.normal.splitAndBalanceSpacebar()),
+            shifted: rightHalf(layout.shifted.splitAndBalanceSpacebar()),
+            symbols1: rightHalf(layout.symbols1.splitAndBalanceSpacebar()),
+            symbols2: rightHalf(layout.symbols2.splitAndBalanceSpacebar())
         )
 
         let leftKeyboardView = KeyboardView(definition: leftDefinition, theme: theme)

--- a/Keyboard/Models/KeyboardDefinition.swift
+++ b/Keyboard/Models/KeyboardDefinition.swift
@@ -208,10 +208,10 @@ public struct KeyboardDefinition: Codable {
         var symbols2: [[KeyDefinition]] = []
     }
 
-    private(set) var layout: Layout?
+    private(set) var currentDeviceLayout: Layout?
 
     public var supportsCurrentDevice: Bool {
-        return layout != nil
+        return currentDeviceLayout != nil
     }
 
     // TODO: features should be derived from as-yet-undefined JSON input
@@ -250,7 +250,7 @@ public struct KeyboardDefinition: Codable {
 
         switch deviceVariant {
         case .iphone:
-            self.layout = Layout(
+            self.currentDeviceLayout = Layout(
                 normal: keyDefinitionsFromRaw(mode.normal),
                 shifted: keyDefinitionsFromRaw(mode.shifted),
                 symbols1: keyDefinitionsFromRaw(mode.symbols1 ?? []),
@@ -275,13 +275,13 @@ public struct KeyboardDefinition: Codable {
                 symbols2Converted = keyDefinitionsFromRaw(symbols2)
             }
 
-            self.layout = Layout(normal: normal, shifted: shifted, symbols1: symbols1Converted, symbols2: symbols2Converted)
+            self.currentDeviceLayout = Layout(normal: normal, shifted: shifted, symbols1: symbols1Converted, symbols2: symbols2Converted)
         }
 
-        layout!.normal.platformize(page: .normal, spaceName: spaceName, returnName: returnName, traits: traits)
-        layout!.shifted.platformize(page: .shifted, spaceName: spaceName, returnName: returnName, traits: traits)
-        layout!.symbols1.platformize(page: .symbols1, spaceName: spaceName, returnName: returnName, traits: traits)
-        layout!.symbols2.platformize(page: .symbols2, spaceName: spaceName, returnName: returnName, traits: traits)
+        currentDeviceLayout!.normal.platformize(page: .normal, spaceName: spaceName, returnName: returnName, traits: traits)
+        currentDeviceLayout!.shifted.platformize(page: .shifted, spaceName: spaceName, returnName: returnName, traits: traits)
+        currentDeviceLayout!.symbols1.platformize(page: .symbols1, spaceName: spaceName, returnName: returnName, traits: traits)
+        currentDeviceLayout!.symbols2.platformize(page: .symbols2, spaceName: spaceName, returnName: returnName, traits: traits)
     }
 
     private func keyDefinitionsFromRaw(_ rawKeyDefinitions: [[RawKeyDefinition]]) -> [[KeyDefinition]] {
@@ -323,7 +323,7 @@ public struct KeyboardDefinition: Codable {
         self.transforms = other.transforms
         self.longPress = other.longPress
 
-        self.layout = Layout(
+        self.currentDeviceLayout = Layout(
             normal: normal,
             shifted: shifted,
             symbols1: symbols1,

--- a/Keyboard/Models/KeyboardDefinition.swift
+++ b/Keyboard/Models/KeyboardDefinition.swift
@@ -201,13 +201,17 @@ public struct KeyboardDefinition: Codable {
     let longPress: [String: [String]]
     let transforms: [String: TransformTree]
 
-    private(set) var normal: [[KeyDefinition]] = []
-    private(set) var shifted: [[KeyDefinition]] = []
-    private(set) var symbols1: [[KeyDefinition]] = []
-    private(set) var symbols2: [[KeyDefinition]] = []
+    struct Layout: Codable {
+        var normal: [[KeyDefinition]] = []
+        var shifted: [[KeyDefinition]] = []
+        var symbols1: [[KeyDefinition]] = []
+        var symbols2: [[KeyDefinition]] = []
+    }
+
+    private(set) var layout: Layout?
 
     public var supportsCurrentDevice: Bool {
-        return normal.isEmpty == false
+        return layout != nil
     }
 
     // TODO: features should be derived from as-yet-undefined JSON input
@@ -240,41 +244,44 @@ public struct KeyboardDefinition: Codable {
 
         guard let mode = mode else {
             // There's no keyboard definition for the device with the given traits
+            // Don't set the layout property and return
             return
         }
 
         switch deviceVariant {
         case .iphone:
-            self.normal = keyDefinitionsFromRaw(mode.normal)
-            self.shifted = keyDefinitionsFromRaw(mode.shifted)
+            self.layout = Layout(
+                normal: keyDefinitionsFromRaw(mode.normal),
+                shifted: keyDefinitionsFromRaw(mode.shifted),
+                symbols1: keyDefinitionsFromRaw(mode.symbols1 ?? []),
+                symbols2: keyDefinitionsFromRaw(mode.symbols2 ?? [])
+            )
 
-            if let symbols1 = mode.symbols1 {
-                self.symbols1 = keyDefinitionsFromRaw(symbols1)
-            }
-            if let symbols2 = mode.symbols2 {
-                self.symbols2 = keyDefinitionsFromRaw(symbols2)
-            }
         case .ipad12in, .ipad9in:
             let alt = mode.alt ?? []
             let altShift = mode.altShift ?? []
             let symbols1 = mode.symbols1 ?? []
             let symbols2 = mode.symbols2 ?? []
 
-            self.normal = keyDefinitionsFromRaw(mode.normal, alternates: alt)
-            self.shifted = keyDefinitionsFromRaw(mode.shifted, alternates: altShift)
+            let normal = keyDefinitionsFromRaw(mode.normal, alternates: alt)
+            let shifted = keyDefinitionsFromRaw(mode.shifted, alternates: altShift)
+            var symbols1Converted: [[KeyDefinition]] = []
+            var symbols2Converted: [[KeyDefinition]] = []
 
             if symbols2.isEmpty {
-                self.symbols1 = keyDefinitionsFromRaw(symbols1)
+                symbols1Converted = keyDefinitionsFromRaw(symbols1)
             } else {
-                self.symbols1 = keyDefinitionsFromRaw(symbols1, alternates: symbols2)
-                self.symbols2 = keyDefinitionsFromRaw(symbols2)
+                symbols1Converted = keyDefinitionsFromRaw(symbols1, alternates: symbols2)
+                symbols2Converted = keyDefinitionsFromRaw(symbols2)
             }
+
+            self.layout = Layout(normal: normal, shifted: shifted, symbols1: symbols1Converted, symbols2: symbols2Converted)
         }
 
-        normal.platformize(page: .normal, spaceName: spaceName, returnName: returnName, traits: traits)
-        shifted.platformize(page: .shifted, spaceName: spaceName, returnName: returnName, traits: traits)
-        symbols1.platformize(page: .symbols1, spaceName: spaceName, returnName: returnName, traits: traits)
-        symbols2.platformize(page: .symbols2, spaceName: spaceName, returnName: returnName, traits: traits)
+        layout!.normal.platformize(page: .normal, spaceName: spaceName, returnName: returnName, traits: traits)
+        layout!.shifted.platformize(page: .shifted, spaceName: spaceName, returnName: returnName, traits: traits)
+        layout!.symbols1.platformize(page: .symbols1, spaceName: spaceName, returnName: returnName, traits: traits)
+        layout!.symbols2.platformize(page: .symbols2, spaceName: spaceName, returnName: returnName, traits: traits)
     }
 
     private func keyDefinitionsFromRaw(_ rawKeyDefinitions: [[RawKeyDefinition]]) -> [[KeyDefinition]] {
@@ -316,10 +323,12 @@ public struct KeyboardDefinition: Codable {
         self.transforms = other.transforms
         self.longPress = other.longPress
 
-        self.normal = normal
-        self.shifted = shifted
-        self.symbols1 = symbols1
-        self.symbols2 = symbols2
+        self.layout = Layout(
+            normal: normal,
+            shifted: shifted,
+            symbols1: symbols1,
+            symbols2: symbols2
+        )
     }
 }
 

--- a/Keyboard/Views/KeyboardView.swift
+++ b/Keyboard/Views/KeyboardView.swift
@@ -40,7 +40,7 @@ final internal class KeyboardView: UIView,
     }
 
     private func keyDefinitionsForPage(_ page: KeyboardPage) -> [[KeyDefinition]] {
-        guard let layout = definition.layout else {
+        guard let layout = definition.currentDeviceLayout else {
             return []
         }
         switch page {

--- a/Keyboard/Views/KeyboardView.swift
+++ b/Keyboard/Views/KeyboardView.swift
@@ -40,15 +40,18 @@ final internal class KeyboardView: UIView,
     }
 
     private func keyDefinitionsForPage(_ page: KeyboardPage) -> [[KeyDefinition]] {
+        guard let layout = definition.layout else {
+            return []
+        }
         switch page {
         case .symbols1:
-            return definition.symbols1
+            return layout.symbols1
         case .symbols2:
-            return definition.symbols2
+            return layout.symbols2
         case .shifted, .capslock:
-            return definition.shifted
+            return layout.shifted
         default:
-            return definition.normal
+            return layout.normal
         }
     }
 


### PR DESCRIPTION
Clean up and make the possibility of a keyboard not being supported on the current device more clear.